### PR TITLE
Added link to Reva and Phoenix tutorial

### DIFF
--- a/docs/content/en/docs/IOP/Deployment/Local/_index.md
+++ b/docs/content/en/docs/IOP/Deployment/Local/_index.md
@@ -22,6 +22,7 @@ yarn dist
 ```
 
 ## Configure Reva
+If you want to configure Reva to run locally with Phoenix you can follow this tutorial: https://reva.link/docs/tutorials/phoenix-tutorial/ 
 
 
 


### PR DESCRIPTION
This is to create a link from the local deployment page to the tutorial showing how to set up Reva together with Phoenix.