### PR TITLE
Fix empty landing page due to no 'markup' section in the docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -59,6 +59,16 @@ languageName ="English"
 # Weight used for sorting.
 weight = 1
 
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+  [markup.highlight]
+      # See a complete list of available styles at https://xyproto.github.io/splash/docs/all.html
+      style = "tango"
+      # Uncomment if you want your chosen highlight style used for code blocks without a specified language
+      # guessSyntax = "true"
+
 # Everything below this are Site Params
 
 [params]

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -8,7 +8,7 @@ linkTitle = "reva"
  <div class="mx-auto">
 	 <h2><b>Unlock scientific collaborations through technology</b></h2>
 	<br>
-	<a class="btn btn-lg btn-primary  mr-3 mb-4" href="{{< relref "/docs" >}}">
+	<a class="btn btn-lg btn-primary  mr-3 mb-4" href="{{< relref "/docs/iop/deployment" >}}">
 		Deploy <i class="fas fa-rocket ml-2"></i>
 	</a>
 	<a class="btn btn-lg btn-primary  mr-3 mb-4" href="{{< relref "/docs" >}}">


### PR DESCRIPTION
Also bump the docsy version in pair with https://github.com/google/docsy-example and point the 'Deployment' button to the right section.