### PR TITLE
Repo URL https://github.com/sciencemesh/sciencemesh

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -83,9 +83,9 @@ copyright = "The ScienceMesh Authors"
 version_menu = "Releases"
 
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-github_repo = "https://github.com/cs3m4eosc-wp2/sciencemesh"
+github_repo = "https://github.com/sciencemesh/sciencemesh"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
-github_project_repo = "https://github.com/cs3m4eosc-wp2/sciencemesh"
+github_project_repo = "https://github.com/sciencemesh/sciencemesh"
 
 # Specify a value here if your content directory is not in your repo's root directory
 github_subdir = "docs"
@@ -145,7 +145,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
 	name = "GitHub"
-	url = "https://github.com/cs3m4eosc-wp2/sciencemesh"
+	url = "https://github.com/sciencemesh/sciencemesh"
 	icon = "fab fa-github"
         desc = "Development takes place here!"
 #[[params.links.developer]]


### PR DESCRIPTION
It seems that https://github.com/sciencemesh/sciencemesh is ahead of https://github.com/cs3m4eosc-wp2/sciencemesh and it also seems like a more logical repo to link to.
This (probably?) affects what the GitHub logo on https://developer.sciencemesh.io/ points to.